### PR TITLE
Fix server-side crash - addFoodEffectTooltip from FD is client-side only.

### DIFF
--- a/src/main/resources/respiteful.mixins.json
+++ b/src/main/resources/respiteful.mixins.json
@@ -7,10 +7,10 @@
     "FoodDataMixin",
     "FoodPropertiesMixin",
     "LivingEntityMixin",
-    "MobEffectInstanceAccessor",
-    "TextUtilsMixin"
+    "MobEffectInstanceAccessor"
   ],
   "client": [
+    "TextUtilsMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This fixes a crash we're having in Valhelsia 5 (5.1.1) caused by the TextUtilsMixin from Respiteful on a dedicated server. The mixin now only loads on a client.

Crash report here, but the commit with the fix should be fairly self-explanatory.

https://mcpaste.com/9fc64288cc1152ff44fa5fac63498f0d